### PR TITLE
fix broken exports compiled with babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["stage-1", "es2015"]
+  "presets": ["stage-1", "es2015"],
+  "plugins": ["add-module-exports"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
     "node": true
   },
   "parser": "babel-eslint",
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: "module"
+  },
   "rules": {
     "comma-spacing": 2,
     "comma-style": [2, "last"],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.2",
     "babel-eslint": "^5.0.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-1": "^6.5.0",
     "eslint": "^2.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import importRule from './rules/import';
 
-export default {
+module.exports = {
   rules: {
     'import': importRule
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import importRule from './rules/import';
 
-module.exports = {
+export default {
   rules: {
     'import': importRule
   },


### PR DESCRIPTION
Babel 6 changes the way it compiles `export default ...`, basically it removed the old hack `module.exports = exports["default"];`. This change breaks the code when eslint loads this plugin.

I also added `parserOptions` for eslint 2.
