### PR TITLE
unpin eslint peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/eslint-plugins/eslint-plugin-lean-imports#readme",
   "peerDependencies": {
-    "eslint": "~2.2.0"
+    "eslint": ">=2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",


### PR DESCRIPTION
There's no reason to pin `eslint` to 2.2.x. The missing dependency in `eslint` 2.3 has been fixed.
